### PR TITLE
Add upload functionality to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,20 @@
 # Run `make clean` to remove all output files except raw data
 # 	(i.e everything but the raw files downloaded from AWS)
 # Run `make clean_all` to remove all output files and raw data
+# Run `make upload` to upload all final training sets to S3 bucket
+# (note that you will need the necessary write permissions to do this)
 
 all : taxons content labelled
 taxons : $(DATADIR)/clean_taxons.csv
 content : $(DATADIR)/clean_content.csv
 labelled : $(DATADIR)/labelled.csv
+new: $(DATADIR)/new_content.csv
 
 $(DATADIR)/new_content.csv : python/create_new.py $(DATADIR)/untagged_content.csv \
     $(DATADIR)/old_taxons.csv
 	python3 python/create_new.py
 
-$(DATADIR)/labelled.csv : python/create_labelled.py $(DATADIR)/raw_taxons.json \
-    taxons content
+$(DATADIR)/labelled.csv : python/create_labelled.py $(DATADIR)/raw_taxons.json
 	python3 python/create_labelled.py
 
 $(DATADIR)/clean_taxons.csv : python/clean_taxons.py $(DATADIR)/raw_taxons.json
@@ -35,13 +37,26 @@ $(DATADIR)/raw_taxons.json :
 $(DATADIR)/raw_content.json.gz :
 	aws s3 cp $(S3BUCKET)/raw_content.json.gz $(DATADIR)/raw_content.json.gz
 
+# Forgive this horrible repetition.
+
+upload: labelled 
+	aws s3 cp $(DATADIR)/untagged_content.csv $(S3BUCKET)/untagged_content.csv
+	aws s3 cp $(DATADIR)/empty_taxons.csv $(S3BUCKET)/empty_taxons.csv
+	aws s3 cp $(DATADIR)/labelled.csv $(S3BUCKET)/labelled.csv
+	aws s3 cp $(DATADIR)/filtered.csv $(S3BUCKET)/filtered.csv
+	aws s3 cp $(DATADIR)/old_taxons.csv $(S3BUCKET)/old_taxons.csv
+	aws s3 cp $(DATADIR)/labelled_level1.csv $(S3BUCKET)/labelled_level1.csv
+	aws s3 cp $(DATADIR)/labelled_level2.csv $(S3BUCKET)/labelled_level2.csv
+	aws s3 cp $(DATADIR)/empty_taxons_not_world.csv $(S3BUCKET)/empty_taxons_not_world.csv
+	aws s3 cp $(DATADIR)/new_content.csv $(S3BUCKET)/new_content.csv
+
+
 clean : 
 	-rm -f $(DATADIR)/clean_taxons.csv $(DATADIR)/clean_content.csv \
 	    $(DATADIR)/untagged_content.csv $(DATADIR)/empty_taxons.csv \
 	    $(DATADIR)/labelled.csv $(DATADIR)/filtered.csv $(DATADIR)/old_taxons.csv \
 	    $(DATADIR)/labelled_level1.csv $(DATADIR)/labelled_level2.csv \
 	    $(DATADIR)/empty_taxons_not_world.csv $(DATADIR)/new_content.csv
-
 
 clean_all : clean
 	-rm -f $(DATADIR)/document_type_group_lookup.json \
@@ -53,4 +68,7 @@ init :
 test : 
 	cd python && python3 -m pytest
 
-.PHONY : init test clean clean_all
+help :
+	@cat Makefile
+
+.PHONY : init test clean clean_all upload help

--- a/python/create_labelled.py
+++ b/python/create_labelled.py
@@ -22,13 +22,13 @@ TAXONS_INPUT_PATH = os.path.join(DATADIR, 'clean_taxons.csv')
 
 # Set file output paths
 
-LABELLED_OUTPUT_PATH = os.path.join(DATADIR, 'labelled.csv')
-FILTERED_OUTPUT_PATH = os.path.join(DATADIR, 'filtered.csv')
-OLD_TAXONS_OUTPUT_PATH = os.path.join(DATADIR, 'old_taxons.csv')
-EMPTY_TAXONS_OUTPUT_PATH = os.path.join(DATADIR, 'empty_taxons.csv')
-LABELLED_LEVEL1_OUTPUT_PATH = os.path.join(DATADIR, 'labelled_level1.csv')
-LABELLED_LEVEL2_OUTPUT_PATH = os.path.join(DATADIR, 'labelled_level2.csv')
-EMPTY_TAXONS_NOT_WORLD_OUTPUT_PATH = os.path.join(DATADIR, 'empty_taxons_not_world.csv')
+LABELLED_OUTPUT_PATH = os.path.join(DATADIR, 'labelled.csv.gz.gz')
+FILTERED_OUTPUT_PATH = os.path.join(DATADIR, 'filtered.csv.gz')
+OLD_TAXONS_OUTPUT_PATH = os.path.join(DATADIR, 'old_taxons.csv.gz')
+EMPTY_TAXONS_OUTPUT_PATH = os.path.join(DATADIR, 'empty_taxons.csv.gz')
+LABELLED_LEVEL1_OUTPUT_PATH = os.path.join(DATADIR, 'labelled_level1.csv.gz')
+LABELLED_LEVEL2_OUTPUT_PATH = os.path.join(DATADIR, 'labelled_level2.csv.gz')
+EMPTY_TAXONS_NOT_WORLD_OUTPUT_PATH = os.path.join(DATADIR, 'empty_taxons_not_world.csv.gz')
 
 # Import clean_content (output by clean_content.py)
 
@@ -308,24 +308,22 @@ except AssertionError:
 # Write out dataframes
 
 write_csv(level1_tagged, 'level1 tagged labelled',
-          LABELLED_LEVEL1_OUTPUT_PATH, logger)
+          LABELLED_LEVEL1_OUTPUT_PATH, logger, compression='gzip')
 
 write_csv(level2_tagged, 'level2 tagged labelled',
-          LABELLED_LEVEL2_OUTPUT_PATH, logger)
+          LABELLED_LEVEL2_OUTPUT_PATH, logger, compression='gzip')
 
-write_csv(labelled, 'labelled', LABELLED_OUTPUT_PATH, logger)
+write_csv(labelled, 'labelled',
+          LABELLED_OUTPUT_PATH, logger, compression='gzip')
 
-write_csv(filtered, 'filtered', FILTERED_OUTPUT_PATH, logger)
+write_csv(filtered, 'filtered',
+          FILTERED_OUTPUT_PATH, logger, compression='gzip')
 
 write_csv(content_old_taxons, 'old_taxons',
-          OLD_TAXONS_OUTPUT_PATH, logger)
-
-# NOTE: I have saved this dataframe out here. In previous versions
-# it was getting overwritten by the empty taxons csv.
+          OLD_TAXONS_OUTPUT_PATH, logger, compression='gzip')
 
 write_csv(empty_taxons_not_world, 'empty_taxons_not_world',
-          EMPTY_TAXONS_NOT_WORLD_OUTPUT_PATH, logger)
+          EMPTY_TAXONS_NOT_WORLD_OUTPUT_PATH, logger, compression='gzip')
 
-logger.info('Writing empty_taxons to %s', EMPTY_TAXONS_OUTPUT_PATH)
 write_csv(empty_taxons, 'empty_taxons',
-          EMPTY_TAXONS_OUTPUT_PATH, logger)
+          EMPTY_TAXONS_OUTPUT_PATH, logger, compression='gzip')

--- a/python/pipeline_functions.py
+++ b/python/pipeline_functions.py
@@ -7,7 +7,7 @@ import pandas as pd
 import numpy as np
 from lxml import etree
 
-def write_csv(dataframe, name, path, logger, index=False):
+def write_csv(dataframe, name, path, logger, index=False, **kwargs):
     '''
     Write a dataframe to CSV with logging
 
@@ -27,7 +27,7 @@ def write_csv(dataframe, name, path, logger, index=False):
 
     try:
 
-        dataframe.to_csv(path, index=index)
+        dataframe.to_csv(path, index=index, **kwargs)
 
     except Exception:
         logger.exception('Error writing %s to %s', name, path)


### PR DESCRIPTION
Add `make upload` command to automatically upload all processed output files to S3. This is required, as it is marginally easier to do this processing locally, and pull just the cleaned data ready for modelling onto an EC2 instance for deep learning, rather than ensuring that all the dependencies of this repository are met on a deep learning instance.